### PR TITLE
Phase 1: CR3BP propagator, zero-velocity curve, and orbit presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,9 @@ All quantities use **normalized CR3BP units**: distance = Sun–Jupiter separati
 Unimplemented stubs throw `UnsupportedOperationException` with a GitHub issue reference. Dependency order:
 
 1. ~~`CR3BPEquations.computeDerivatives` (issue #1)~~ — **done**
-2. `LagrangePointCalculator.computeAll` (issue #2) — no dependencies
-3. `StateVectorPropagator.propagate` (issue #3) — depends on #1 ✓; constructor-injected with `CR3BPEquations` + `JacobiConstant`
-4. `ZeroVelocityCurve.computeForbiddenRegion` (issue #5) — depends on `JacobiConstant.effectivePotential` ✓; constructor-injected with `JacobiConstant`
+2. ~~`LagrangePointCalculator.computeAll` / L1–L5 (issue #2)~~ — **done**
+3. ~~`StateVectorPropagator.propagate` (issue #3)~~ — **done** (DormandPrince853 + StepHandler recording per-step Jacobi)
+4. ~~`ZeroVelocityCurve.computeForbiddenRegion` (issue #5)~~ — **done**
 5. `OrbitPresets` state vectors (issue #6) — placeholder `StateVector(0,0,0,0)` values need literature-validated initial conditions
 
 ## Collaboration Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Unimplemented stubs throw `UnsupportedOperationException` with a GitHub issue re
 2. ~~`LagrangePointCalculator.computeAll` / L1–L5 (issue #2)~~ — **done**
 3. ~~`StateVectorPropagator.propagate` (issue #3)~~ — **done** (DormandPrince853 + StepHandler recording per-step Jacobi)
 4. ~~`ZeroVelocityCurve.computeForbiddenRegion` (issue #5)~~ — **done**
-5. `OrbitPresets` state vectors (issue #6) — placeholder `StateVector(0,0,0,0)` values need literature-validated initial conditions
+5. ~~`OrbitPresets` state vectors (issue #6)~~ — **done** (tadpole L4/L5 seeded at triangular points + 3e-3 radial offset; horseshoe at `(-1.00045, 0, 0, 0.0012)`; Jacobi constants computed at class-load from the seed state)
 
 ## Collaboration Notes
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ The simulator lets you explore:
 
 ### Roadmap
 
-#### Phase 1 – Core Physics (In Progress)
+#### Phase 1 – Core Physics (Complete)
 - [x] CR3BP dynamical model
 - [x] Lagrange point calculator
 - [x] State vector propagation with adaptive step size
 - [x] Jacobi constant calculation
 - [x] Zero-velocity curves visualization
-- [ ] Preset tadpole and horseshoe orbit examples
+- [x] Preset tadpole and horseshoe orbit examples
 
 #### Phase 2 – Web Application
 - [ ] Responsive Angular UI with reactive forms

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ The simulator lets you explore:
 
 #### Phase 1 – Core Physics (In Progress)
 - [x] CR3BP dynamical model
-- [ ] Lagrange point calculator
-- [ ] State vector propagation with adaptive step size
+- [x] Lagrange point calculator
+- [x] State vector propagation with adaptive step size
 - [x] Jacobi constant calculation
-- [ ] Zero-velocity curves visualization
+- [x] Zero-velocity curves visualization
 - [ ] Preset tadpole and horseshoe orbit examples
 
 #### Phase 2 – Web Application

--- a/src/main/java/org/github/oleksandrkukotin/physics/StateVectorPropagator.java
+++ b/src/main/java/org/github/oleksandrkukotin/physics/StateVectorPropagator.java
@@ -1,8 +1,17 @@
 package org.github.oleksandrkukotin.physics;
 
+import org.apache.commons.math3.exception.MaxCountExceededException;
+import org.apache.commons.math3.ode.nonstiff.DormandPrince853Integrator;
+import org.apache.commons.math3.ode.sampling.StepHandler;
+import org.apache.commons.math3.ode.sampling.StepInterpolator;
 import org.github.oleksandrkukotin.model.SimulationRequest;
+import org.github.oleksandrkukotin.model.StateVector;
+import org.github.oleksandrkukotin.model.TrajectoryPoint;
 import org.github.oleksandrkukotin.model.TrajectoryResult;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Propagates a CR3BP state vector forward in time using an adaptive step-size ODE integrator.
@@ -30,9 +39,29 @@ public class StateVectorPropagator {
      * @return full trajectory with per-step Jacobi constant values
      */
     public TrajectoryResult propagate(SimulationRequest request) {
-        // TODO (#3): Set up DormandPrince853Integrator with request tolerances,
-        // attach a StepHandler that records TrajectoryPoints (state + jacobiConstant),
-        // integrate from t=0 to t=request.duration(), and return a TrajectoryResult.
-        throw new UnsupportedOperationException("Not yet implemented — see issue #3");
+        DormandPrince853Integrator integrator = new DormandPrince853Integrator(
+                request.minStep(), request.maxStep(),
+                request.absoluteTolerance(), request.relativeTolerance());
+
+        List<TrajectoryPoint> points = new ArrayList<>();
+
+        integrator.addStepHandler(new StepHandler() {
+            @Override
+            public void init(double t0, double[] y0, double t) {}
+            @Override
+            public void handleStep(StepInterpolator interpolator, boolean isLast) throws MaxCountExceededException {
+                double t = interpolator.getCurrentTime();
+                StateVector stateVector = StateVector.fromArray(interpolator.getInterpolatedState());
+                points.add(new TrajectoryPoint(t, stateVector, jacobiConstant.compute(stateVector)));
+            }
+        });
+
+        double[] y0 = request.initialState().toArray();
+        double[] yOut = new double[4];
+        integrator.integrate(equations, 0.0, y0, request.duration(), yOut);
+
+        double cInitial = jacobiConstant.compute(request.initialState());
+        double cFinal = points.get(points.size() - 1).jacobiConstant();
+        return new TrajectoryResult(points, cInitial, cFinal);
     }
 }

--- a/src/main/java/org/github/oleksandrkukotin/physics/ZeroVelocityCurve.java
+++ b/src/main/java/org/github/oleksandrkukotin/physics/ZeroVelocityCurve.java
@@ -34,8 +34,17 @@ public class ZeroVelocityCurve {
                                               double xMin, double xMax,
                                               double yMin, double yMax,
                                               int resolution) {
-        // TODO (#5): For each grid cell, evaluate 2 * jacobiConstant.effectivePotential(x, y)
-        // and compare to jacobiC. Mark as forbidden where 2Ω < C.
-        throw new UnsupportedOperationException("Not yet implemented — see issue #5");
+        boolean[][] grid = new boolean[resolution][resolution];
+        double dx = (xMax - xMin) / (resolution - 1);
+        double dy = (yMax - yMin) / (resolution - 1);
+
+        for (int i = 0; i < resolution; i++) {
+            double x = xMin + i * dx;
+            for (int j = 0; j < resolution; j++) {
+                double y = yMin + j * dy;
+                grid[i][j] = 2.0 * jacobiConstant.effectivePotential(x, y) < jacobiC;
+            }
+        }
+        return grid;
     }
 }

--- a/src/main/java/org/github/oleksandrkukotin/presets/OrbitPresets.java
+++ b/src/main/java/org/github/oleksandrkukotin/presets/OrbitPresets.java
@@ -1,7 +1,9 @@
 package org.github.oleksandrkukotin.presets;
 
+import org.github.oleksandrkukotin.config.PhysicsConstants;
 import org.github.oleksandrkukotin.model.OrbitPreset;
 import org.github.oleksandrkukotin.model.StateVector;
+import org.github.oleksandrkukotin.physics.JacobiConstant;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -10,43 +12,54 @@ import java.util.List;
  * Hardcoded initial conditions for well-known Sun–Jupiter CR3BP orbits.
  *
  * <p>All state vectors use normalized units in the rotating synodic frame.
- * Placeholder zeros must be replaced with validated values from literature.
  *
  * @see <a href="https://github.com/OleksandrKukotin/sun-jupiter-threebody-simulator/issues/6">Issue #6</a>
  */
 @Component
 public class OrbitPresets {
 
-    /**
-     * Returns all available orbit presets.
-     * TODO (#6): Replace placeholder StateVectors, durations, and Jacobi constants
-     *            with values validated against the propagator.
-     */
+    private static final double L4_X = 0.5 - PhysicsConstants.MU;
+    private static final double L4_Y =  Math.sqrt(3.0) / 2.0;
+    private static final double L5_Y = -Math.sqrt(3.0) / 2.0;
+
+    // Small radial displacement from the triangular point seeds the long-period
+    // libration while keeping the orbit inside the tadpole regime.
+    private static final double TADPOLE_DX = 3.0e-3;
+
+    private static final JacobiConstant JACOBI = new JacobiConstant();
+
+    private static final StateVector TADPOLE_L4_STATE =
+            new StateVector(L4_X + TADPOLE_DX, L4_Y, 0.0, 0.0);
+    private static final StateVector TADPOLE_L5_STATE =
+            new StateVector(L4_X + TADPOLE_DX, L5_Y, 0.0, 0.0);
+    private static final StateVector HORSESHOE_STATE =
+            new StateVector(-1.00045, 0.0, 0.0, 0.0012);
+
     public List<OrbitPreset> getAll() {
         return List.of(
                 new OrbitPreset(
                         "tadpole-l4",
                         "Tadpole orbit around L4",
                         "Small-amplitude libration around Jupiter's L4 (Greek camp, leading 60°)",
-                        new StateVector(0.0, 0.0, 0.0, 0.0), // TODO (#6)
-                        0.0,  // TODO (#6): integration duration (normalized time units)
-                        0.0   // TODO (#6): expected Jacobi constant
+                        TADPOLE_L4_STATE,
+                        100.0,
+                        JACOBI.compute(TADPOLE_L4_STATE)
                 ),
                 new OrbitPreset(
                         "tadpole-l5",
                         "Tadpole orbit around L5",
                         "Small-amplitude libration around Jupiter's L5 (Trojan camp, trailing 60°)",
-                        new StateVector(0.0, 0.0, 0.0, 0.0), // TODO (#6)
-                        0.0,
-                        0.0
+                        TADPOLE_L5_STATE,
+                        100.0,
+                        JACOBI.compute(TADPOLE_L5_STATE)
                 ),
                 new OrbitPreset(
                         "horseshoe",
                         "Horseshoe orbit",
                         "Large-amplitude orbit librating around both L4 and L5 via L3",
-                        new StateVector(0.0, 0.0, 0.0, 0.0), // TODO (#6)
-                        0.0,
-                        0.0
+                        HORSESHOE_STATE,
+                        2000.0,
+                        JACOBI.compute(HORSESHOE_STATE)
                 )
         );
     }

--- a/src/test/java/org/github/oleksandrkukotin/physics/StateVectorPropagatorTest.java
+++ b/src/test/java/org/github/oleksandrkukotin/physics/StateVectorPropagatorTest.java
@@ -1,0 +1,105 @@
+package org.github.oleksandrkukotin.physics;
+
+import org.github.oleksandrkukotin.config.PhysicsConstants;
+import org.github.oleksandrkukotin.model.SimulationRequest;
+import org.github.oleksandrkukotin.model.StateVector;
+import org.github.oleksandrkukotin.model.TrajectoryPoint;
+import org.github.oleksandrkukotin.model.TrajectoryResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StateVectorPropagatorTest {
+
+    private StateVectorPropagator propagator;
+    private JacobiConstant jacobiConstant;
+
+    private static final double ABS_TOL = 1e-12;
+    private static final double REL_TOL = 1e-12;
+    private static final double MIN_STEP = 1e-8;
+    private static final double MAX_STEP = 1.0;
+
+    @BeforeEach
+    void setUp() {
+        jacobiConstant = new JacobiConstant();
+        propagator = new StateVectorPropagator(new CR3BPEquations(), jacobiConstant);
+    }
+
+    private SimulationRequest request(StateVector s0, double duration) {
+        return new SimulationRequest(s0, duration, ABS_TOL, REL_TOL, MIN_STEP, MAX_STEP);
+    }
+
+    @Test
+    void propagate_producesNonEmptyTrajectoryWithMonotonicTime() {
+        StateVector s0 = new StateVector(0.5, 0.1, 0.0, 0.5);
+        TrajectoryResult result = propagator.propagate(request(s0, 2.0));
+
+        List<TrajectoryPoint> pts = result.points();
+        assertFalse(pts.isEmpty(), "trajectory must contain at least one recorded step");
+        for (int i = 1; i < pts.size(); i++) {
+            assertTrue(pts.get(i).time() > pts.get(i - 1).time(),
+                    "time must be strictly increasing at step " + i);
+        }
+    }
+
+    @Test
+    void propagate_reachesRequestedDuration() {
+        StateVector s0 = new StateVector(0.5, 0.1, 0.0, 0.5);
+        double duration = 3.0;
+        TrajectoryResult result = propagator.propagate(request(s0, duration));
+
+        double finalTime = result.points().get(result.points().size() - 1).time();
+        assertEquals(duration, finalTime, 1e-9);
+    }
+
+    @Test
+    void propagate_conservesJacobiConstant() {
+        // Jacobi's constant is a first integral of the CR3BP — a well-tuned
+        // Dormand–Prince 8(5,3) run should hold |ΔC/C| well below 1e-10.
+        StateVector s0 = new StateVector(0.5, 0.1, 0.0, 0.5);
+        TrajectoryResult result = propagator.propagate(request(s0, 5.0));
+
+        double cInit = result.initialJacobiConstant();
+        double cFin  = result.finalJacobiConstant();
+        double relDrift = Math.abs(cFin - cInit) / Math.abs(cInit);
+        assertTrue(relDrift < 1e-10, "Jacobi drift too large: " + relDrift);
+    }
+
+    @Test
+    void propagate_startsFromInitialStateJacobi() {
+        StateVector s0 = new StateVector(0.5, 0.1, 0.0, 0.5);
+        TrajectoryResult result = propagator.propagate(request(s0, 1.0));
+
+        assertEquals(jacobiConstant.compute(s0), result.initialJacobiConstant(), 1e-12);
+    }
+
+    @Test
+    void propagate_atL4WithZeroVelocity_stateStaysNearL4() {
+        // L4 is an equilibrium; with zero velocity the state should barely move
+        // over a modest integration interval (linear instability is weak at Sun–Jupiter μ).
+        StateVector l4 = new StateVector(0.5 - PhysicsConstants.MU, Math.sqrt(3) / 2.0, 0.0, 0.0);
+        TrajectoryResult result = propagator.propagate(request(l4, 1.0));
+
+        StateVector last = result.points().get(result.points().size() - 1).state();
+        assertEquals(l4.x(),    last.x(),    1e-8);
+        assertEquals(l4.y(),    last.y(),    1e-8);
+        assertEquals(l4.xDot(), last.xDot(), 1e-8);
+        assertEquals(l4.yDot(), last.yDot(), 1e-8);
+    }
+
+    @Test
+    void propagate_jacobiConstantIsConsistentAlongEveryStep() {
+        StateVector s0 = new StateVector(0.5, 0.1, 0.0, 0.5);
+        TrajectoryResult result = propagator.propagate(request(s0, 4.0));
+
+        double cInit = result.initialJacobiConstant();
+        for (TrajectoryPoint p : result.points()) {
+            double relDrift = Math.abs(p.jacobiConstant() - cInit) / Math.abs(cInit);
+            assertTrue(relDrift < 1e-10,
+                    "Jacobi drift at t=" + p.time() + " was " + relDrift);
+        }
+    }
+}

--- a/src/test/java/org/github/oleksandrkukotin/physics/ZeroVelocityCurveTest.java
+++ b/src/test/java/org/github/oleksandrkukotin/physics/ZeroVelocityCurveTest.java
@@ -1,0 +1,94 @@
+package org.github.oleksandrkukotin.physics;
+
+import org.github.oleksandrkukotin.config.PhysicsConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ZeroVelocityCurveTest {
+
+    private ZeroVelocityCurve zvc;
+    private JacobiConstant jacobi;
+
+    @BeforeEach
+    void setUp() {
+        jacobi = new JacobiConstant();
+        zvc = new ZeroVelocityCurve(jacobi);
+    }
+
+    @Test
+    void computeForbiddenRegion_returnsSquareGridMatchingResolution() {
+        boolean[][] grid = zvc.computeForbiddenRegion(3.0, -1.5, 1.5, -1.5, 1.5, 50);
+        assertEquals(50, grid.length);
+        for (boolean[] row : grid) {
+            assertEquals(50, row.length);
+        }
+    }
+
+    @Test
+    void computeForbiddenRegion_isSymmetricAboutXAxis() {
+        // Ω(x, y) = Ω(x, −y) because r1, r2 depend on |y|.
+        int n = 41;
+        boolean[][] grid = zvc.computeForbiddenRegion(3.0, -1.5, 1.5, -1.5, 1.5, n);
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                assertEquals(grid[i][j], grid[i][n - 1 - j],
+                        "asymmetry at (" + i + "," + j + ")");
+            }
+        }
+    }
+
+    @Test
+    void computeForbiddenRegion_veryLowC_allowsEverything() {
+        // C ≪ 2Ω_min means 2Ω > C everywhere → nothing forbidden.
+        boolean[][] grid = zvc.computeForbiddenRegion(-100.0, -1.5, 1.5, -1.5, 1.5, 30);
+        for (boolean[] row : grid) {
+            for (boolean cell : row) {
+                assertFalse(cell, "no cell should be forbidden at C = -100");
+            }
+        }
+    }
+
+    @Test
+    void computeForbiddenRegion_veryHighC_forbidsEverything() {
+        // C ≫ 2Ω everywhere on the grid → every cell forbidden.
+        // The primaries themselves are at x = -μ and x = 1-μ; keep the grid off them
+        // (singular Ω → 2Ω > any finite C there, so those cells would be "allowed").
+        boolean[][] grid = zvc.computeForbiddenRegion(1e6, 0.2, 0.8, 0.2, 0.8, 20);
+        for (boolean[] row : grid) {
+            for (boolean cell : row) {
+                assertTrue(cell, "every cell should be forbidden at C = 1e6");
+            }
+        }
+    }
+
+    @Test
+    void computeForbiddenRegion_atL4_justBelowCL4_L4CellIsAccessible() {
+        // At L4, 2Ω(L4) = C_L4 (zero-velocity equilibrium). For C slightly below C_L4,
+        // the neighborhood of L4 is accessible (not forbidden).
+        double xL4 = 0.5 - PhysicsConstants.MU;
+        double yL4 = Math.sqrt(3) / 2.0;
+        double cL4 = 2.0 * jacobi.effectivePotential(xL4, yL4);
+
+        int n = 21;
+        double half = 0.05;
+        boolean[][] grid = zvc.computeForbiddenRegion(
+                cL4 - 1e-6, xL4 - half, xL4 + half, yL4 - half, yL4 + half, n);
+
+        // Center cell ≈ L4 must be accessible.
+        assertFalse(grid[n / 2][n / 2], "L4 itself must be accessible for C < C_L4");
+    }
+
+    @Test
+    void computeForbiddenRegion_primaryCellsAreAccessible() {
+        // Ω diverges to +∞ at the primaries, so 2Ω is never < C there → not forbidden.
+        int n = 11; // odd → center cell at i = n/2
+        double mu = PhysicsConstants.MU;
+
+        // Grid centered on Jupiter at (1 − μ, 0).
+        double cx = 1.0 - mu;
+        boolean[][] grid = zvc.computeForbiddenRegion(1e6, cx - 0.1, cx + 0.1, -0.1, 0.1, n);
+        assertFalse(grid[n / 2][n / 2], "cell at Jupiter must be accessible (Ω → ∞)");
+    }
+}

--- a/src/test/java/org/github/oleksandrkukotin/presets/OrbitPresetsValidationTest.java
+++ b/src/test/java/org/github/oleksandrkukotin/presets/OrbitPresetsValidationTest.java
@@ -1,0 +1,148 @@
+package org.github.oleksandrkukotin.presets;
+
+import org.github.oleksandrkukotin.config.PhysicsConstants;
+import org.github.oleksandrkukotin.model.OrbitPreset;
+import org.github.oleksandrkukotin.model.SimulationRequest;
+import org.github.oleksandrkukotin.model.TrajectoryPoint;
+import org.github.oleksandrkukotin.model.TrajectoryResult;
+import org.github.oleksandrkukotin.physics.CR3BPEquations;
+import org.github.oleksandrkukotin.physics.JacobiConstant;
+import org.github.oleksandrkukotin.physics.StateVectorPropagator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validation harness for the three Phase-1 orbit presets. Each preset is
+ * propagated with tight tolerances and checked for:
+ *   1. Jacobi constant conservation at every recorded step (|ΔC/C| < 1e-8)
+ *   2. Agreement between the stored expectedJacobiConstant and the true value
+ *   3. A regime-specific spatial bounding box (tadpoles stay near L4/L5,
+ *      horseshoe wraps both triangular points without hitting Jupiter).
+ *
+ * Use this test to iterate on the initial conditions in {@link OrbitPresets}
+ * until all assertions pass, then lock the numbers in.
+ */
+class OrbitPresetsValidationTest {
+
+    private static final double ABS_TOL = 1e-12;
+    private static final double REL_TOL = 1e-12;
+    private static final double MIN_STEP = 1e-8;
+    private static final double MAX_STEP = 1.0;
+
+    private static final double JACOBI_DRIFT_TOL = 1e-8;
+
+    private static final double MU = PhysicsConstants.MU;
+    private static final double L4_X = 0.5 - MU;
+    private static final double L4_Y =  Math.sqrt(3.0) / 2.0;
+    private static final double L5_Y = -Math.sqrt(3.0) / 2.0;
+
+    private OrbitPresets presets;
+    private StateVectorPropagator propagator;
+    private JacobiConstant jacobi;
+
+    @BeforeEach
+    void setUp() {
+        presets = new OrbitPresets();
+        jacobi = new JacobiConstant();
+        propagator = new StateVectorPropagator(new CR3BPEquations(), jacobi);
+    }
+
+    @Test
+    void tadpoleL4_staysBoundedNearL4() {
+        OrbitPreset p = presets.findById("tadpole-l4");
+        TrajectoryResult r = propagate(p);
+
+        assertJacobiConserved(r, p);
+        assertAllPointsWithin(r, L4_X, L4_Y, 0.15,
+                "tadpole-l4 drifted outside 0.15 of L4");
+        // tadpole stays on the leading (y > 0) side
+        for (TrajectoryPoint pt : r.points()) {
+            assertTrue(pt.state().y() > 0.3,
+                    "tadpole-l4 crossed below y=0.3 at t=" + pt.time());
+        }
+    }
+
+    @Test
+    void tadpoleL5_staysBoundedNearL5() {
+        OrbitPreset p = presets.findById("tadpole-l5");
+        TrajectoryResult r = propagate(p);
+
+        assertJacobiConserved(r, p);
+        assertAllPointsWithin(r, L4_X, L5_Y, 0.15,
+                "tadpole-l5 drifted outside 0.15 of L5");
+        for (TrajectoryPoint pt : r.points()) {
+            assertTrue(pt.state().y() < -0.3,
+                    "tadpole-l5 crossed above y=-0.3 at t=" + pt.time());
+        }
+    }
+
+    @Test
+    void horseshoe_wrapsBothTriangularPointsWithoutHittingJupiter() {
+        OrbitPreset p = presets.findById("horseshoe");
+        TrajectoryResult r = propagate(p);
+
+        assertJacobiConserved(r, p);
+
+        boolean sawLeading = false;   // y > +0.5 (near L4)
+        boolean sawTrailing = false;  // y < -0.5 (near L5)
+        double jupiterX = 1.0 - MU;
+        double minDistToJupiter = Double.POSITIVE_INFINITY;
+
+        for (TrajectoryPoint pt : r.points()) {
+            double y = pt.state().y();
+            if (y >  0.5) sawLeading  = true;
+            if (y < -0.5) sawTrailing = true;
+
+            double dx = pt.state().x() - jupiterX;
+            double dy = pt.state().y();
+            minDistToJupiter = Math.min(minDistToJupiter, Math.hypot(dx, dy));
+        }
+
+        assertTrue(sawLeading,  "horseshoe never reached the L4 side");
+        assertTrue(sawTrailing, "horseshoe never reached the L5 side");
+        assertTrue(minDistToJupiter > 0.1,
+                "horseshoe came too close to Jupiter: " + minDistToJupiter);
+    }
+
+    @Test
+    void expectedJacobiConstant_matchesInitialState() {
+        for (OrbitPreset p : presets.getAll()) {
+            double actual = jacobi.compute(p.initialState());
+            assertEquals(p.expectedJacobiConstant(), actual, 1e-10,
+                    "expectedJacobiConstant mismatch for preset " + p.id());
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private TrajectoryResult propagate(OrbitPreset p) {
+        SimulationRequest req = new SimulationRequest(
+                p.initialState(), p.duration(),
+                ABS_TOL, REL_TOL, MIN_STEP, MAX_STEP);
+        return propagator.propagate(req);
+    }
+
+    private void assertJacobiConserved(TrajectoryResult r, OrbitPreset p) {
+        double c0 = r.initialJacobiConstant();
+        for (TrajectoryPoint pt : r.points()) {
+            double drift = Math.abs(pt.jacobiConstant() - c0) / Math.abs(c0);
+            assertTrue(drift < JACOBI_DRIFT_TOL,
+                    "preset " + p.id() + ": Jacobi drift " + drift
+                            + " at t=" + pt.time());
+        }
+    }
+
+    private void assertAllPointsWithin(TrajectoryResult r,
+                                       double cx, double cy,
+                                       double radius, String msg) {
+        for (TrajectoryPoint pt : r.points()) {
+            double dx = pt.state().x() - cx;
+            double dy = pt.state().y() - cy;
+            double d  = Math.hypot(dx, dy);
+            assertTrue(d <= radius,
+                    msg + " (d=" + d + " at t=" + pt.time() + ")");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `StateVectorPropagator` using `DormandPrince853Integrator` with a step handler that records per-step Jacobi constant
- Implement `ZeroVelocityCurve.computeForbiddenRegion` to produce the boolean grid of inaccessible regions
- Seed `OrbitPresets` with tadpole L4/L5 (triangular points + 3e-3 radial offset) and horseshoe `(-1.00045, 0, 0, 0.0012)` presets; Jacobi constants computed at class-load

## Test plan
- [x] `./gradlew test` — `StateVectorPropagatorTest`, `ZeroVelocityCurveTest`, `OrbitPresetsValidationTest` all pass
- [x] Jacobi constant conservation verified along propagated trajectories

## Summary by Sourcery

Implement numerical CR3BP state propagation with Jacobi tracking, zero-velocity forbidden-region computation, and validated Sun–Jupiter orbit presets, completing the Phase 1 core physics milestones.

New Features:
- Add a Dormand–Prince-based state vector propagator that returns full trajectories with per-step Jacobi constants.
- Add zero-velocity curve support that computes forbidden spatial regions for a given Jacobi constant.
- Introduce preset tadpole (L4/L5) and horseshoe Sun–Jupiter orbits with predefined durations and Jacobi constants.

Enhancements:
- Update roadmap and internal implementation checklist to mark core physics items as complete and document the finalized orbit presets.

Tests:
- Add validation tests for orbit presets covering Jacobi conservation, expected constant accuracy, and qualitative orbital behavior.
- Add unit tests for the state vector propagator to verify trajectory output, time monotonicity, Jacobi conservation, and L4 equilibrium behavior.
- Add unit tests for zero-velocity curve computation to check grid shape, symmetry, limiting C behavior, and behavior near Lagrange points and primaries.